### PR TITLE
Add bloom interaction for Rapunzel flower

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/RapunzelFlower.tsx
+++ b/src/components/RapunzelFlower.tsx
@@ -3,41 +3,58 @@ import React, { useEffect, useState } from 'react';
 
 const RapunzelFlower = () => {
   const [sparkles, setSparkles] = useState<Array<{ id: number; x: number; y: number; delay: number }>>([]);
+  const [isBlooming, setIsBlooming] = useState(false);
 
-  useEffect(() => {
-    const sparkleArray = Array.from({ length: 12 }, (_, i) => ({
+  const generateSparkles = () =>
+    Array.from({ length: 12 }, (_, i) => ({
       id: i,
       x: Math.random() * 100,
       y: Math.random() * 100,
       delay: Math.random() * 2
     }));
-    setSparkles(sparkleArray);
+
+  useEffect(() => {
+    setSparkles(generateSparkles());
   }, []);
 
+  const handleBloom = () => {
+    if (!isBlooming) {
+      setIsBlooming(true);
+      setSparkles(generateSparkles());
+    }
+  };
+
   return (
-    <div className="relative w-64 h-64 mx-auto animate-float">
+    <div
+      className="relative w-64 h-64 mx-auto animate-float cursor-pointer"
+      onClick={handleBloom}
+    >
       {/* Sparkles around the flower */}
-      {sparkles.map((sparkle) => (
-        <div
-          key={sparkle.id}
-          className="absolute w-2 h-2 bg-gradient-to-r from-rapunzel-gold to-rapunzel-pink rounded-full animate-sparkle"
-          style={{
-            left: `${sparkle.x}%`,
-            top: `${sparkle.y}%`,
-            animationDelay: `${sparkle.delay}s`
-          }}
-        />
-      ))}
+      {isBlooming &&
+        sparkles.map((sparkle) => (
+          <div
+            key={sparkle.id}
+            className="absolute w-2 h-2 bg-gradient-to-r from-rapunzel-gold to-rapunzel-pink rounded-full animate-sparkle"
+            style={{
+              left: `${sparkle.x}%`,
+              top: `${sparkle.y}%`,
+              animationDelay: `${sparkle.delay}s`
+            }}
+          />
+        ))}
       
       {/* Flower stem */}
-      <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-2 h-32 bg-gradient-to-t from-green-600 to-green-400 rounded-full"></div>
+      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-32 bg-gradient-to-t from-green-600 to-green-400 rounded-full"></div>
       
       {/* Leaves */}
       <div className="absolute bottom-20 left-1/2 transform -translate-x-8 w-8 h-4 bg-green-500 rounded-full rotate-45 animate-petal-sway"></div>
       <div className="absolute bottom-16 left-1/2 transform translate-x-4 w-6 h-3 bg-green-400 rounded-full -rotate-45 animate-petal-sway" style={{ animationDelay: '0.5s' }}></div>
       
       {/* Flower center */}
-      <div className="absolute top-8 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-16 h-16 bg-gradient-to-br from-rapunzel-gold to-yellow-400 rounded-full animate-glow shadow-lg">
+      <div
+        className="absolute top-8 left-1/2 w-16 h-16 bg-gradient-to-br from-rapunzel-gold to-yellow-400 rounded-full animate-glow shadow-lg transition-transform duration-700"
+        style={{ transform: `translate(-50%, -50%) scale(${isBlooming ? 1 : 0})` }}
+      >
         <div className="absolute inset-2 bg-gradient-to-br from-yellow-300 to-rapunzel-gold rounded-full animate-pulse"></div>
       </div>
       
@@ -48,9 +65,9 @@ const RapunzelFlower = () => {
         return (
           <div
             key={i}
-            className="absolute top-8 left-1/2 origin-bottom transform -translate-x-1/2 -translate-y-full animate-petal-sway"
-            style={{ 
-              transform: `translateX(-50%) translateY(-100%) rotate(${rotation}deg)`,
+            className={`absolute top-8 left-1/2 origin-bottom transition-transform duration-700 ${isBlooming ? 'animate-petal-sway' : ''}`}
+            style={{
+              transform: `translateX(-50%) translateY(-100%) rotate(${rotation}deg) scale(${isBlooming ? 1 : 0})`,
               animationDelay: `${delay}s`
             }}
           >
@@ -64,20 +81,21 @@ const RapunzelFlower = () => {
       
       {/* Inner petals */}
       {Array.from({ length: 6 }).map((_, i) => {
-        const rotation = (i * 60) + 30;
+        const rotation = i * 60 + 30;
         const delay = i * 0.15;
         return (
           <div
             key={`inner-${i}`}
-            className="absolute top-12 left-1/2 origin-bottom transform -translate-x-1/2 -translate-y-full animate-petal-sway"
-            style={{ 
-              transform: `translateX(-50%) translateY(-100%) rotate(${rotation}deg)`,
+            className={`absolute top-12 left-1/2 origin-bottom transition-transform duration-700 ${isBlooming ? 'animate-petal-sway' : ''}`}
+            style={{
+              transform: `translateX(-50%) translateY(-100%) rotate(${rotation}deg) scale(${isBlooming ? 1 : 0})`,
               animationDelay: `${delay}s`
             }}
           >
-            <div className="w-6 h-12 bg-gradient-to-t from-rapunzel-pink via-purple-400 to-rapunzel-lightPurple rounded-full shadow-md animate-glow opacity-90"
-                 style={{ transformOrigin: 'center bottom' }}>
-            </div>
+            <div
+              className="w-6 h-12 bg-gradient-to-t from-rapunzel-pink via-purple-400 to-rapunzel-lightPurple rounded-full shadow-md animate-glow opacity-90"
+              style={{ transformOrigin: 'center bottom' }}
+            ></div>
           </div>
         );
       })}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,13 +10,18 @@ const Index = () => {
 
   useEffect(() => {
     // Efecto de entrada cuando se abre la carta
+    let contentTimer: ReturnType<typeof setTimeout>;
+
     const timer = setTimeout(() => {
       setIsVisible(true);
       // Mostrar contenido después de un breve delay
-      setTimeout(() => setShowContent(true), 500);
+      contentTimer = setTimeout(() => setShowContent(true), 500);
     }, 300);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      clearTimeout(contentTimer);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add click-triggered bloom animation
- regenerate sparkles when blooming
- ensure both timers in `Index` are cleaned up
- set document language to Spanish

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685759d6cac4832f99960e383e4e9dfe